### PR TITLE
Done #6: passing Term class to fields parse methods

### DIFF
--- a/src/whoosh/qparser/default.py
+++ b/src/whoosh/qparser/default.py
@@ -213,7 +213,8 @@ class QueryParser(object):
             # and return early
             if field.self_parsing():
                 try:
-                    q = field.parse_query(fieldname, text, boost=boost)
+                    q = field.parse_query(fieldname, text, boost=boost,
+                                          termclass=termclass)
                     return q
                 except:
                     e = sys.exc_info()[1]

--- a/src/whoosh/qparser/plugins.py
+++ b/src/whoosh/qparser/plugins.py
@@ -26,6 +26,7 @@
 # policies, either expressed or implied, of Matt Chaput.
 
 import copy
+import functools
 
 from whoosh import query
 from whoosh.compat import u
@@ -510,6 +511,9 @@ class FuzzyTermPlugin(TaggingPlugin):
             self.endchar = wordnode.endchar
             self.maxdist = maxdist
             self.prefixlength = prefixlength
+            # Set FuzzyTerm-specific attributes
+            self.qclass = functools.partial(self.qclass, maxdist=maxdist,
+                                            prefixlength=prefixlength)
 
         def r(self):
             return "%r ~%d/%d" % (self.text, self.maxdist, self.prefixlength)
@@ -519,9 +523,6 @@ class FuzzyTermPlugin(TaggingPlugin):
             # (it looks at self.qclass), just because it takes care of some
             # extra checks and attributes
             q = syntax.TextNode.query(self, parser)
-            # Set FuzzyTerm-specific attributes
-            q.maxdist = self.maxdist
-            q.prefixlength = self.prefixlength
             return q
 
     def create(self, parser, match):


### PR DESCRIPTION
Additionally bugfix: set `FuzzyTerm`-sepecific always on the` FuzzyTerm` instance and not e.g. on `And` group field (which happened when using `NGRAMWORDS` field).