### PR TITLE
remove duplicate_plugin WhitespacePlugin

### DIFF
--- a/src/whoosh/qparser/default.py
+++ b/src/whoosh/qparser/default.py
@@ -92,7 +92,8 @@ class QueryParser(object):
 
         from whoosh.qparser import plugins
 
-        return [plugins.WhitespacePlugin(),
+        return [
+                # plugins.WhitespacePlugin(),
                 plugins.SingleQuotePlugin(),
                 plugins.FieldsPlugin(),
                 plugins.WildcardPlugin(),


### PR DESCRIPTION
I find that 
class `QueryParser` has code
```
if plugins is None:
    plugins = self.default_set()
self._add_ws_plugin()
self.add_plugins(plugins)
```
However, when var `plugins` is `None`, `WhitespacePlugin` will in variable `plugins`, It makes `WhitespacePlugin` appeared twice