### PR TITLE
[RFC] Give SegmentWriter a cachable Searcher

### DIFF
--- a/src/whoosh/writing.py
+++ b/src/whoosh/writing.py
@@ -545,6 +545,7 @@ class SegmentWriter(IndexWriter):
         self.merge = True
         self.optimize = False
         self.mergetype = None
+        self._searcher = None
 
     def __repr__(self):
         # Author: Ronald Evers
@@ -809,6 +810,18 @@ class SegmentWriter(IndexWriter):
             raise Exception("Per-doc writer is still open")
         return self.codec.per_document_reader(self.storage, self.get_segment())
 
+    def searcher(self, **kwargs):
+        # If possible, cache a Searcher that doesn't close until we want it to.
+        # We have a write lock, nothing is changing. Only cache if kwargs is emtpy.
+        if kwargs:
+            return super(SegmentWriter, self).searcher(**kwargs)
+
+        if self._searcher is None:
+            s = self._searcher = super(SegmentWriter, self).searcher()
+            s._orig_close = s.close # called in _finish()
+            s.close = lambda: None
+        return self._searcher
+
     # The following methods break out the commit functionality into smaller
     # pieces to allow MpWriter to call them individually
 
@@ -890,6 +903,10 @@ class SegmentWriter(IndexWriter):
         clean_files(self.storage, self.indexname, self.generation, segments)
 
     def _finish(self):
+        if self._searcher is not None:
+            # Close the cached Searcher if we have one.
+            self._searcher._orig_close()
+            self._searcher = None
         self._tempstorage.destroy()
         if self.writelock:
             self.writelock.release()


### PR DESCRIPTION
When repeatedly calling `update_document()`, each call instantiates a `Searcher`, which is expensive. The `SegmentWriter` already has a write lock on the index, so if the conditions are right, let's cache a `Searcher`, override its `close()` method to keep it open, and close it on `_finish()` if it's around.

I think this is safe, but I don't know enough about whoosh to be certain. All tests are still passing, and I didn't break any django-haystack tests with this change either.