### PR TITLE
Add support for wildcard regex tokenization

### DIFF
--- a/src/whoosh/analysis/tokenizers.py
+++ b/src/whoosh/analysis/tokenizers.py
@@ -30,7 +30,7 @@ from whoosh.analysis.acore import Composable, Token
 from whoosh.util.text import rcompile
 
 
-default_pattern = rcompile(r"\w+(\.?\w+)*")
+default_pattern = rcompile(r"[\w\*]+(\.?[\w\*]+)*")
 
 
 # Tokenizers

--- a/src/whoosh/fields.py
+++ b/src/whoosh/fields.py
@@ -1224,8 +1224,12 @@ class NGRAM(FieldType):
     def parse_query(self, fieldname, qstring, boost=1.0):
         from whoosh import query
 
-        terms = [query.Term(fieldname, g)
-                 for g in self.process_text(qstring, mode='query')]
+        terms = []
+        for g in self.process_text(qstring, mode='query'):
+            if g == "*":
+                terms.append(query.Wildcard(fieldname, g, boost=boost))
+            else:
+                terms.append(query.Term(fieldname, g, boost=boost))
         cls = query.Or if self.queryor else query.And
 
         return cls(terms, boost=boost)


### PR DESCRIPTION
Updated default regex pattern for tokenizers to include the wildcard symbol (`*`).
Additionally, N-gram queries now support wildcard search query strings.

This basis for this pull request is to resolve a long-term issue experienced by [Django Haystack](https://github.com/django-haystack/django-haystack) users where wildcard searches (i.e. searches without filtering such as `SearchQuerySet()` and `SearchQuerySet.all()`) always return 0 hits.

Issues:

* Fixes django-haystack/django-haystack#1021

Stack Overflow Posts:

* [django-haystack + Whoosh SearchQuerySet().all() always None](https://stackoverflow.com/questions/38913004/django-haystack-whoosh-searchqueryset-all-always-none)
* [Django Haystack & Whoosh Search Working, But SearchQuerySet Return 0 Results](https://stackoverflow.com/questions/40378644/django-haystack-whoosh-search-working-but-searchqueryset-return-0-results)