### PR TITLE
[chore] fix "SyntaxError: invalid escape sequence"

### DIFF
--- a/src/whoosh/analysis/filters.py
+++ b/src/whoosh/analysis/filters.py
@@ -53,7 +53,7 @@ url_pattern = rcompile("""
     \\S+?                  # URL body
     (?=\\s|[.]\\s|$|[.]$)  # Stop at space/end, or a dot followed by space/end
 ) | (                      # or...
-    \w+([:.]?\w+)*         # word characters, with opt. internal colons/dots
+    \\w+([:.]?\\w+)*         # word characters, with opt. internal colons/dots
 )
 """, verbose=True)
 
@@ -145,7 +145,7 @@ class MultiFilter(Filter):
 
 
 class TeeFilter(Filter):
-    """Interleaves the results of two or more filters (or filter chains).
+    r"""Interleaves the results of two or more filters (or filter chains).
 
     NOTE: because it needs to create copies of each token for each sub-filter,
     this filter is quite slow.

--- a/src/whoosh/analysis/intraword.py
+++ b/src/whoosh/analysis/intraword.py
@@ -34,7 +34,7 @@ from whoosh.analysis.filters import Filter
 
 
 class CompoundWordFilter(Filter):
-    """Given a set of words (or any object with a ``__contains__`` method),
+    r"""Given a set of words (or any object with a ``__contains__`` method),
     break any tokens in the stream that are composites of words in the word set
     into their individual parts.
 
@@ -272,7 +272,7 @@ class IntraWordFilter(Filter):
     >>> iwf_i = IntraWordFilter(mergewords=True, mergenums=True)
     >>> iwf_q = IntraWordFilter(mergewords=False, mergenums=False)
     >>> iwf = MultiFilter(index=iwf_i, query=iwf_q)
-    >>> analyzer = RegexTokenizer(r"\S+") | iwf | LowercaseFilter()
+    >>> analyzer = RegexTokenizer(r"\\S+") | iwf | LowercaseFilter()
 
     (See :class:`MultiFilter`.)
     """
@@ -282,7 +282,7 @@ class IntraWordFilter(Filter):
     __inittypes__ = dict(delims=text_type, splitwords=bool, splitnums=bool,
                          mergewords=bool, mergenums=bool)
 
-    def __init__(self, delims=u("-_'\"()!@#$%^&*[]{}<>\|;:,./?`~=+"),
+    def __init__(self, delims=u("-_'\"()!@#$%^&*[]{}<>\\|;:,./?`~=+"),
                  splitwords=True, splitnums=True,
                  mergewords=False, mergenums=False):
         """

--- a/src/whoosh/lang/paicehusk.py
+++ b/src/whoosh/lang/paicehusk.py
@@ -30,7 +30,7 @@ class PaiceHuskStemmer(object):
     (?P<cont>[.>])
     """, re.UNICODE | re.VERBOSE)
 
-    stem_expr = re.compile("^\w+", re.UNICODE)
+    stem_expr = re.compile(r"^\w+", re.UNICODE)
 
     def __init__(self, ruletable):
         """

--- a/src/whoosh/lang/porter2.py
+++ b/src/whoosh/lang/porter2.py
@@ -64,7 +64,7 @@ def remove_initial_apostrophe(word):
 def capitalize_consonant_ys(word):
     if word.startswith('y'):
         word = 'Y' + word[1:]
-    return ccy_exp.sub('\g<1>Y', word)
+    return ccy_exp.sub(r'\g<1>Y', word)
 
 
 def step_0(word):

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -520,7 +520,7 @@ def test_stop_lang():
 
 
 def test_issue358():
-    t = analysis.RegexTokenizer("\w+")
+    t = analysis.RegexTokenizer(r"\w+")
     with pytest.raises(analysis.CompositionError):
         _ = t | analysis.StandardAnalyzer()
 


### PR DESCRIPTION
If you use this library with [PYTHONWARNINGS=error::DeprecationWarning](https://docs.python.org/3/library/warnings.html#describing-warning-filters), you are met with the following error,
```
File ".../whoosh/analysis/filters.py", line 50
--
  | url_pattern = rcompile("""
  | ^
  | SyntaxError: invalid escape sequence \w
--
```

This change was purely mechanical; I ran `ruff check --fix --select W605` on the repository, https://beta.ruff.rs/docs/rules/#warning-w.


---
```
==================================================== 587 passed in 8.58s =====================================================
.pkg: _exit> python /usr/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py27: SKIP (0.01 seconds)
  py33: SKIP (0.00 seconds)
  py34: SKIP (0.00 seconds)
  py35: SKIP (0.00 seconds)
  py36: SKIP (0.00 seconds)
  py37: OK (15.99=setup[7.18]+cmd[8.81] seconds)
  congratulations :) (16.06 seconds)
```
___

You can also repro the errors with the following diff 
```
diff --git a/tox.ini b/tox.ini
index bf5bfd6..34aa21c 100644
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, py37
+envlist = py27, py33, py34, py35, py36, py37, py39
 
 [testenv]
 deps =
        pytest
        pytest-pep8
-commands = py.test -s {posargs} tests
+commands = py.test -W error::DeprecationWarning -s {posargs} tests
```
which yields,
```
__________________________________________ ERROR collecting tests/test_analysis.py ___________________________________________
.tox/py39/lib/python3.9/site-packages/_pytest/python.py:617: in _importtestmodule
    mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
.tox/py39/lib/python3.9/site-packages/_pytest/pathlib.py:565: in import_path
    importlib.import_module(module_name)
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:986: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:680: in _load_unlocked
    ???
.tox/py39/lib/python3.9/site-packages/_pytest/assertion/rewrite.py:169: in exec_module
    source_stat, co = _rewrite_test(fn, self.config)
.tox/py39/lib/python3.9/site-packages/_pytest/assertion/rewrite.py:351: in _rewrite_test
    tree = ast.parse(source, filename=strfn)
/usr/lib/python3.9/ast.py:50: in parse
    return compile(source, filename, mode, flags,
E     File "/home/jamison/code/third-party/whoosh/tests/test_analysis.py", line 523
E       t = analysis.RegexTokenizer("\w+")
E                                   ^
E   SyntaxError: invalid escape sequence \w

```